### PR TITLE
Fix named_modules

### DIFF
--- a/lib/torch/nn/module.rb
+++ b/lib/torch/nn/module.rb
@@ -187,7 +187,7 @@ module Torch
       end
 
       # TODO return enumerator?
-      def named_modules(memo: nil, prefix: "")
+      def named_modules(memo: [], prefix: "")
         ret = {}
         memo ||= Set.new
         unless memo.include?(self)


### PR DESCRIPTION
Fix undefined method `include?' for nil:NilClass in Torch::NN::Module#named_modules