### PR TITLE
Fixed a typo in variable name

### DIFF
--- a/lib/torch/nn/transformer_decoder_layer.rb
+++ b/lib/torch/nn/transformer_decoder_layer.rb
@@ -35,7 +35,7 @@ module Torch
         tgt += @dropout2.(tgt2)
         tgt = @norm2.(tgt)
         tgt2 = @linear2.(@dropout.(@activation.(@linear1.(tgt))))
-        tgt += @dropout3.(tgt)
+        tgt += @dropout3.(tgt2)
         @norm3.(tgt)
       end
     end


### PR DESCRIPTION
Hi, @ankane.
Found a typo during active transformer use.
For some reason the result of a decoder with initial xavier uniform weights isn't affected by this typo so the test was ok.