### PR TITLE
Allow loading large model files

### DIFF
--- a/ext/torch/torch.cpp
+++ b/ext/torch/torch.cpp
@@ -62,11 +62,15 @@ void init_torch(Rice::Module& m) {
       })
     .define_singleton_function(
       "_load",
-      [](const std::string &s) {
-        std::vector<char> v;
-        std::copy(s.begin(), s.end(), std::back_inserter(v));
+      [](const std::string filename) {
         // https://github.com/pytorch/pytorch/issues/20356#issuecomment-567663701
-        return torch::pickle_load(v);
+        std::ifstream input(filename, std::ios::binary);
+        std::vector<char> bytes(
+            (std::istreambuf_iterator<char>(input)),
+            (std::istreambuf_iterator<char>()));
+
+        input.close();
+        return torch::pickle_load(bytes);
       })
     .define_singleton_function(
       "_from_blob",

--- a/lib/torch.rb
+++ b/lib/torch.rb
@@ -388,7 +388,7 @@ module Torch
     end
 
     def load(f)
-      to_ruby(_load(File.binread(f)))
+      to_ruby(_load(f))
     end
 
     def tensor(data, **options)


### PR DESCRIPTION
Loading large models > 2.5GB in Ruby with `File.binread` fails with an error:

```
binread': Invalid argument @ io_fread - ./model.pth (Errno::EINVAL)
```

This change should allow loading arbitrarily large models as long as enough memory is available.