### PR TITLE
Fix `SystemStackError` in `Torch::Tensor#<=>`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fixed `SystemStackError` with `Torch::Tensor#<=>`.
+
 ## 0.19.1 (2025-02-10)
 
 - Fixed error with Rice 4.5

--- a/lib/torch/tensor.rb
+++ b/lib/torch/tensor.rb
@@ -159,7 +159,7 @@ module Torch
 
     # TODO better compare?
     def <=>(other)
-      item <=> other
+      -1 * (other <=> item)
     end
 
     # based on python_variable_indexing.cpp and

--- a/test/tensor_methods_test.rb
+++ b/test/tensor_methods_test.rb
@@ -30,6 +30,17 @@ class TensorMethodsTest < Minitest::Test
     assert_equal :float64, x.to(dtype: :float64).dtype
   end
 
+  def test_comparison_operator
+    x = Torch.tensor(42)
+
+    assert_equal 0, 42 <=> x
+    assert_equal 0, x <=> 42
+    assert_equal -1, 35.0 <=> x
+    assert_equal 1, x <=> 35.0
+    assert_equal -1, x <=> 1138
+    assert_equal 1, 1138 <=> x
+  end
+
   def test_to_symbol
     x = Torch.tensor([1, 2, 3])
     assert_equal :float64, x.to(:float64).dtype


### PR DESCRIPTION
Fixes a `SystemStackError` when attempting to compare with a tensor on the right hand side.

```ruby
irb(main):001> require 'torch'
=> true
irb(main):002> 42 <=> Torch.tensor(42)
/home/RuhmUndAnsehen/.gem/ruby/gems/torch-rb-0.19.1/lib/torch.rb:424:in `block in tensor': stack level too deep (SystemStackError)
```

The cause is the number being converted to a tensor, then converted to a number via `#item` again, and so on. The fix simply switches the operands and multiplies with -1 to keep the property intact.