### PR TITLE
Add TorchScript support

### DIFF
--- a/ext/torch/ext.cpp
+++ b/ext/torch/ext.cpp
@@ -14,6 +14,7 @@ void init_cuda(Rice::Module& m);
 void init_device(Rice::Module& m);
 void init_generator(Rice::Module& m, Rice::Class& rb_cGenerator);
 void init_ivalue(Rice::Module& m, Rice::Class& rb_cIValue);
+void init_jit(Rice::Module& m, Rice::Class& rb_cScriptModule);
 void init_random(Rice::Module& m);
 
 VALUE rb_eTorchError = Qnil;
@@ -31,6 +32,7 @@ void Init_ext() {
   auto rb_cTensor = Rice::define_class_under<torch::Tensor>(m, "Tensor");
   auto rb_cTensorOptions = Rice::define_class_under<torch::TensorOptions>(m, "TensorOptions")
     .define_constructor(Rice::Constructor<torch::TensorOptions>());
+  auto rb_cScriptModule = Rice::define_class_under<torch::jit::script::Module>(m, "ScriptModule");
 
   // keep this order
   init_torch(m);
@@ -45,5 +47,6 @@ void Init_ext() {
   init_cuda(m);
   init_generator(m, rb_cGenerator);
   init_ivalue(m, rb_cIValue);
+  init_jit(m, rb_cScriptModule);
   init_random(m);
 }

--- a/ext/torch/jit.cpp
+++ b/ext/torch/jit.cpp
@@ -1,0 +1,88 @@
+#include <torch/torch.h>
+#include <torch/script.h>
+
+#include <rice/rice.hpp>
+
+#include "utils.h"
+
+void init_jit(Rice::Module& m, Rice::Class& rb_cScriptModule) {
+  auto rb_mJit = Rice::define_module_under(m, "Jit");
+
+  rb_mJit
+    .define_singleton_function(
+      "load",
+      [](const std::string& path, Rice::Object device_obj) {
+        c10::optional<torch::Device> device = c10::nullopt;
+        if (!device_obj.is_nil()) {
+          device = Rice::detail::From_Ruby<torch::Device>().convert(device_obj.value());
+        }
+        return torch::jit::load(path, device);
+      },
+      Rice::Arg("path"), Rice::Arg("device") = Rice::Object());
+
+  rb_cScriptModule
+    .define_method(
+      "forward",
+      [](torch::jit::script::Module& self, Rice::Array args) {
+        std::vector<torch::jit::IValue> inputs;
+        for (auto arg : args) {
+          inputs.push_back(Rice::detail::From_Ruby<torch::Tensor>().convert(arg.value()));
+        }
+
+        auto output = self.forward(inputs);
+
+        if (output.isTensor()) {
+          return Rice::Object(Rice::detail::To_Ruby<torch::Tensor>().convert(output.toTensor()));
+        } else if (output.isTuple()) {
+          auto tuple = output.toTuple();
+          Rice::Array result;
+          for (const auto& elem : tuple->elements()) {
+            if (elem.isTensor()) {
+              result.push(Rice::Object(Rice::detail::To_Ruby<torch::Tensor>().convert(elem.toTensor())), false);
+            } else {
+              result.push(Rice::Object(Rice::detail::To_Ruby<torch::IValue>().convert(elem)), false);
+            }
+          }
+          return Rice::Object(result);
+        } else {
+          return Rice::Object(Rice::detail::To_Ruby<torch::IValue>().convert(output));
+        }
+      })
+    .define_method(
+      "eval",
+      [](torch::jit::script::Module& self) {
+        self.eval();
+        return self;
+      })
+    .define_method(
+      "to",
+      [](torch::jit::script::Module& self, Rice::Object device_obj) {
+        c10::optional<torch::Device> device = c10::nullopt;
+
+        if (!device_obj.is_nil()) {
+          device = Rice::detail::From_Ruby<torch::Device>().convert(device_obj.value());
+        }
+
+        if (device.has_value()) {
+          self.to(device.value());
+        }
+
+        return self;
+      },
+      Rice::Arg("device") = Rice::Object())
+    .define_method(
+      "save",
+      [](torch::jit::script::Module& self, const std::string& path) {
+        self.save(path);
+      })
+    .define_method(
+      "parameters",
+      [](torch::jit::script::Module& self, bool recurse) {
+        Rice::Array params;
+        for (const auto& param : self.parameters(recurse)) {
+          params.push(Rice::Object(Rice::detail::To_Ruby<torch::Tensor>().convert(param)), false);
+        }
+        return params;
+      },
+      Rice::Arg("recurse") = true);
+}

--- a/lib/torch.rb
+++ b/lib/torch.rb
@@ -19,6 +19,9 @@ require_relative "torch/distributions/exponential_family"
 require_relative "torch/distributions/normal"
 require_relative "torch/distributions/utils"
 
+# jit
+require_relative "torch/jit"
+
 # optim
 require_relative "torch/optim/optimizer"
 require_relative "torch/optim/adadelta"

--- a/lib/torch/jit.rb
+++ b/lib/torch/jit.rb
@@ -1,0 +1,17 @@
+module Torch
+  module Jit
+    class << self
+      alias _load load
+
+      def load(path, device: nil)
+        device_obj = device ? Torch.device(device) : nil
+
+        _load(path, device_obj)
+      end
+    end
+  end
+
+  class ScriptModule
+    alias call forward
+  end
+end


### PR DESCRIPTION
This PR adds basic support for `torch.jit` (TorchScript) module for inference:
https://docs.pytorch.org/docs/stable/jit.html 

```ruby
model = Torch::Jit.load('traced_model.pt', device: 'cuda')
model.eval

input = Torch.tensor([...]).to('cuda')
output = model.call([input])
```