### PR TITLE
Multi GPU support

### DIFF
--- a/ext/torch/cuda.cpp
+++ b/ext/torch/cuda.cpp
@@ -1,5 +1,9 @@
 #include <torch/torch.h>
 
+#ifdef USE_CUDA
+#include <c10/cuda/CUDAFunctions.h>
+#endif
+
 #include <rice/rice.hpp>
 
 #include "utils.h"
@@ -8,6 +12,39 @@ void init_cuda(Rice::Module& m) {
   Rice::define_module_under(m, "CUDA")
     .define_singleton_function("available?", &torch::cuda::is_available)
     .define_singleton_function("device_count", &torch::cuda::device_count)
+    .define_singleton_function("current_device", []() -> int {
+#ifdef USE_CUDA
+      if (torch::cuda::is_available()) {
+        return static_cast<int>(c10::cuda::current_device());
+      }
+#endif
+      return 0;
+    })
+    .define_singleton_function("set_device", [](int device) {
+#ifdef USE_CUDA
+      if (torch::cuda::is_available()) {
+        c10::cuda::set_device(static_cast<c10::DeviceIndex>(device));
+        return;
+      }
+#endif
+      if (device != 0) {
+        throw std::runtime_error("CUDA is not available");
+      }
+    })
+    .define_singleton_function("synchronize", []() {
+#ifdef USE_CUDA
+      if (torch::cuda::is_available()) {
+        c10::cuda::device_synchronize();
+      }
+#endif
+    })
     .define_singleton_function("manual_seed", &torch::cuda::manual_seed)
-    .define_singleton_function("manual_seed_all", &torch::cuda::manual_seed_all);
+    .define_singleton_function("manual_seed_all", &torch::cuda::manual_seed_all)
+    .define_singleton_function("nccl_available?", []() -> bool {
+#ifdef USE_NCCL
+      return true;
+#else
+      return false;
+#endif
+    });
 }

--- a/lib/torch.rb
+++ b/lib/torch.rb
@@ -50,6 +50,11 @@ require_relative "torch/nn/module_list"
 require_relative "torch/nn/parameter_list"
 require_relative "torch/nn/sequential"
 
+# nn parallel
+require_relative "torch/nn/parallel/replicate"
+require_relative "torch/nn/parallel/parallel_apply"
+require_relative "torch/nn/parallel/data_parallel"
+
 # nn convolution layers
 require_relative "torch/nn/convnd"
 require_relative "torch/nn/conv1d"

--- a/lib/torch/nn/parallel/data_parallel.rb
+++ b/lib/torch/nn/parallel/data_parallel.rb
@@ -1,0 +1,279 @@
+module Torch
+  module NN
+    module Parallel
+      # Implements data parallelism at the module level.
+      #
+      # This container parallelizes the application of the given module by
+      # splitting the input across the specified devices by chunking in the
+      # batch dimension. In the forward pass, the module is replicated on each
+      # device, and each replica handles a portion of the input. During the
+      # backwards pass, gradients from each replica are summed into the
+      # original module.
+      #
+      # @note Backward Pass for Models Returning Loss
+      #   When your model returns a scalar loss (e.g., GPT models that return
+      #   [logits, loss]), you must use the {#backward} method instead of
+      #   calling loss.backward directly. This is because gathering scalar
+      #   tensors across devices breaks the autograd graph in torch.rb.
+      #
+      #   @example Training loop with loss-returning model
+      #     dp_model = Torch::NN::DataParallel.new(model, device_ids: [0, 1])
+      #     optimizer.zero_grad
+      #     logits, loss = dp_model.call(input, targets: targets)
+      #     dp_model.backward(scale: 1.0 / gradient_accumulation_steps)
+      #     optimizer.step
+      #
+      # @example Basic usage (model returns output only)
+      #   model = MyModel.new.to("cuda:0")
+      #   parallel_model = Torch::NN::DataParallel.new(model, device_ids: [0, 1])
+      #   output = parallel_model.call(input)
+      #   loss = criterion.call(output, target)
+      #   loss.backward  # Standard backward works when loss computed after gather
+      #
+      class DataParallel < Module
+        attr_reader :module, :device_ids, :output_device, :dim
+        alias_method :wrapped_module, :module
+
+        # @param mod [Torch::NN::Module] Module to parallelize
+        # @param device_ids [Array<Integer>, nil] CUDA devices (default: all available)
+        # @param output_device [Integer, nil] Device for output (default: device_ids[0])
+        # @param dim [Integer] Dimension to scatter inputs along (default: 0)
+        def initialize(mod, device_ids: nil, output_device: nil, dim: 0)
+          super()
+          @module = mod
+          @device_ids = device_ids || (0...Torch::CUDA.device_count).to_a
+          @output_device = output_device || @device_ids.first
+          @dim = dim
+          @replica_losses = nil
+
+          if @device_ids.empty?
+            raise ArgumentError, "device_ids cannot be empty"
+          end
+
+          # Convert to device strings for internal use
+          @device_strings = @device_ids.map { |id| "cuda:#{id}" }
+          @output_device_string = "cuda:#{@output_device}"
+        end
+
+        def forward(*inputs, **kwargs)
+          # Empty input check
+          if inputs.empty?
+            return @module.call(**kwargs)
+          end
+
+          # Single GPU fast path
+          if @device_ids.size == 1
+            return @module.call(*inputs.map { |i| i.to(@device_strings.first) }, **kwargs)
+          end
+
+          # Scatter inputs across devices
+          scattered_inputs = scatter(inputs, @device_strings, @dim)
+          scattered_kwargs = scatter_kwargs(kwargs, @device_strings, @dim)
+
+          # Get or create replicas, sync weights
+          num_replicas = scattered_inputs.size
+          devices = @device_strings[0...num_replicas]
+          @replicas = get_replicas(devices)
+          sync_replica_weights
+
+          # Apply in parallel
+          outputs = parallel_apply(@replicas, scattered_inputs, scattered_kwargs)
+
+          # Ensure all CUDA operations complete before gathering
+          Torch::CUDA.synchronize if Torch::CUDA.available?
+
+          # Gather outputs back to output device
+          gather(outputs, @output_device_string, @dim)
+        end
+
+        # Performs backward pass on all replica losses and reduces gradients.
+        # This is needed because gather creates a new tensor that breaks the
+        # autograd connection across devices. By calling backward on each
+        # replica's loss separately, gradients flow properly.
+        #
+        # @param scale [Float] Scale factor for gradients (e.g., 1.0/gradient_accumulation_steps)
+        def backward(scale: 1.0)
+          if @replica_losses && @replica_losses.size > 1
+            # Each replica's loss contributes equally to total loss
+            # Scale by 1/N to average gradients across replicas
+            replica_scale = scale / @replica_losses.size
+
+            @replica_losses.each do |replica_loss|
+              # Scale the loss before backward to get properly scaled gradients
+              scaled_loss = replica_loss * replica_scale
+              scaled_loss.backward
+            end
+
+            @replica_losses = nil
+          end
+
+          # Reduce gradients from all replicas to the original module
+          reduce_gradients
+        end
+
+        # Reduce gradients from replicas back to the original module.
+        # Called automatically by backward(), but can be called manually if needed.
+        def reduce_gradients
+          return if @replicas.nil? || @replicas.size <= 1
+
+          # Get original model's parameters (first replica is the original)
+          original_params = @module.parameters.to_a
+
+          # Accumulate gradients from other replicas
+          @replicas[1..].each do |replica|
+            replica_params = replica.parameters.to_a
+            original_params.zip(replica_params).each do |orig, repl|
+              next unless repl.grad
+
+              # Move replica gradient to original device and add
+              if orig.grad
+                orig.grad.add!(repl.grad.to(orig.device))
+              else
+                orig.grad = repl.grad.to(orig.device).clone
+              end
+            end
+          end
+        end
+
+        # Delegate training mode to wrapped module
+        def train(mode = true)
+          super
+          @module.train(mode)
+          self
+        end
+
+        def eval
+          train(false)
+        end
+
+        # Delegate parameter access to wrapped module
+        def parameters
+          @module.parameters
+        end
+
+        def named_parameters(prefix: "", recurse: true)
+          @module.named_parameters(prefix: prefix, recurse: recurse)
+        end
+
+        def state_dict(destination: nil, prefix: "")
+          @module.state_dict(destination: destination, prefix: prefix)
+        end
+
+        def load_state_dict(state_dict, strict: true)
+          @module.load_state_dict(state_dict, strict: strict)
+        end
+
+        def extra_inspect
+          format("device_ids: %s, output_device: %s, dim: %d", @device_ids, @output_device, @dim)
+        end
+
+        private
+
+        # Scatter a single value across devices
+        def scatter_value(value, devices, dim)
+          if value.is_a?(Torch::Tensor)
+            NN._scatter(value, devices, dim).map(&:contiguous)
+          else
+            devices.map { value }
+          end
+        end
+
+        def scatter(inputs, devices, dim)
+          # Scatter each input, then transpose to group by device
+          scattered = inputs.map { |input| scatter_value(input, devices, dim) }
+          scattered.first.size.times.map { |i| scattered.map { |s| s[i] } }
+        end
+
+        def scatter_kwargs(kwargs, devices, dim)
+          return devices.map { {} } if kwargs.empty?
+          scattered = kwargs.transform_values { |v| scatter_value(v, devices, dim) }
+          devices.size.times.map { |i| scattered.transform_values { |v| v[i] } }
+        end
+
+        def get_replicas(devices)
+          # Return cached replicas if they match the requested devices
+          if @replicas && @replica_devices == devices
+            return @replicas
+          end
+
+          # Create new replicas and cache them
+          @replica_devices = devices
+          Parallel.replicate(@module, devices)
+        end
+
+        def sync_replica_weights
+          return if @replicas.nil? || @replicas.size <= 1
+
+          # Sync parameters in-place to avoid memory allocation
+          original_params = @module.parameters.to_a
+          @replicas[1..].each do |replica|
+            replica.parameters.to_a.each_with_index do |param, i|
+              param.data.copy!(original_params[i].data)
+            end
+          end
+        end
+
+        def parallel_apply(replicas, inputs, kwargs_list)
+          Parallel.parallel_apply(replicas, inputs, kwargs_list)
+        end
+
+        def gather(outputs, target_device, dim)
+          # Handle different output types
+          first = outputs.first
+
+          case first
+          when Torch::Tensor
+            gather_tensor(outputs, target_device, dim)
+          when Array
+            # Tuple/array of tensors - gather each element
+            first.size.times.map do |i|
+              tensors = outputs.map { |o| o[i] }
+              if tensors.first.is_a?(Torch::Tensor)
+                gather_tensor(tensors, target_device, dim)
+              elsif tensors.first.nil?
+                nil
+              else
+                tensors.first # Non-tensor, just return first
+              end
+            end
+          when Hash
+            # Dict of tensors - gather each value
+            first.keys.map do |key|
+              tensors = outputs.map { |o| o[key] }
+              if tensors.first.is_a?(Torch::Tensor)
+                [key, gather_tensor(tensors, target_device, dim)]
+              else
+                [key, tensors.first]
+              end
+            end.to_h
+          else
+            # Scalar or other - return first output
+            first
+          end
+        end
+
+        def gather_tensor(tensors, target_device, dim)
+          first = tensors.first
+          # Handle scalar tensors (0-dim) - store for backward, return average for display
+          if first.dim == 0
+            # Store individual losses for backward() method
+            @replica_losses = tensors
+
+            # Return mean of losses (moved to same device) for logging/display
+            # Note: This returned tensor should NOT be used for backward() - use backward() instead
+            # target_device is already a string like "cuda:0"
+            sum = tensors.reduce(Torch.tensor(0.0, device: target_device)) do |acc, t|
+              acc + t.to(target_device).detach
+            end
+            sum / tensors.size
+          else
+            NN._gather(tensors, target_device, dim)
+          end
+        end
+      end
+    end
+
+    # Convenience alias at NN level
+    DataParallel = Parallel::DataParallel
+  end
+end

--- a/lib/torch/nn/parallel/parallel_apply.rb
+++ b/lib/torch/nn/parallel/parallel_apply.rb
@@ -1,0 +1,60 @@
+module Torch
+  module NN
+    module Parallel
+      class << self
+        # Applies modules to inputs in parallel across devices.
+        #
+        # @param modules [Array<Torch::NN::Module>] List of module replicas
+        # @param inputs [Array] List of inputs, one per module
+        # @param kwargs_list [Array<Hash>, nil] Optional list of kwargs, one per module
+        # @return [Array] List of outputs, one per module
+        def parallel_apply(modules, inputs, kwargs_list = nil)
+          kwargs_list ||= modules.map { {} }
+
+          unless modules.size == inputs.size && modules.size == kwargs_list.size
+            raise ArgumentError, "modules, inputs, and kwargs_list must have the same length"
+          end
+
+          # Single module - no parallelism needed
+          if modules.size == 1
+            return [apply_module(modules[0], inputs[0], kwargs_list[0])]
+          end
+
+          parallel_apply_threads(modules, inputs, kwargs_list)
+        end
+
+        private
+
+        def parallel_apply_threads(modules, inputs, kwargs_list)
+          results = Array.new(modules.size)
+          errors = Array.new(modules.size)
+
+          threads = modules.each_with_index.map do |mod, i|
+            Thread.new(mod, inputs[i], kwargs_list[i], i) do |m, inp, kw, idx|
+              results[idx] = apply_module(m, inp, kw)
+            rescue => e
+              errors[idx] = e
+            end
+          end
+
+          threads.each(&:join)
+
+          # Re-raise first error if any
+          errors.each_with_index do |err, i|
+            raise err if err
+          end
+
+          results
+        end
+
+        def apply_module(mod, input, kwargs)
+          if input.is_a?(Array)
+            mod.call(*input, **kwargs)
+          else
+            mod.call(input, **kwargs)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/torch/nn/parallel/replicate.rb
+++ b/lib/torch/nn/parallel/replicate.rb
@@ -1,0 +1,174 @@
+module Torch
+  module NN
+    module Parallel
+      class << self
+        # Replicates a module on multiple devices.
+        #
+        # @param network [Torch::NN::Module] The module to replicate
+        # @param devices [Array<String>] List of device strings (e.g., ["cuda:0", "cuda:1"])
+        # @return [Array<Torch::NN::Module>] List of module replicas, one per device
+        #
+        # Note: The first device uses the original network (not a copy) to ensure
+        # gradients flow back to the original parameters during backward pass.
+        def replicate(network, devices)
+          devices = devices.map { |d| d.is_a?(String) ? d : "cuda:#{d}" }
+
+          # Single device - just return the network (already on correct device)
+          return [network] if devices.size == 1
+
+          # Get the state dict once for creating replicas
+          state_dict = network.state_dict
+
+          # Create replicas - first device uses original network for gradient flow
+          devices.each_with_index.map do |device, idx|
+            if idx == 0
+              # First device: use the original network to maintain gradient connection
+              network
+            else
+              # Other devices: create independent replicas
+              replica = deep_copy_module(network)
+
+              # Copy state dict tensors to the target device
+              # Filter to only include keys that exist in the replica
+              replica_keys = replica.state_dict.keys
+              device_state = state_dict.select { |k, _| replica_keys.include?(k) }
+                                       .transform_values { |t| t.to(device) }
+              replica.load_state_dict(device_state)
+              replica.to(device)
+              replica.train(network.instance_variable_get(:@training))
+              replica
+            end
+          end
+        end
+
+        private
+
+        # Creates a deep copy of a module structure
+        def deep_copy_module(mod)
+          # Check for custom replication hook first
+          return mod.class._replicate(mod) if mod.class.respond_to?(:_replicate)
+
+          # Handle container modules
+          return copy_sequential(mod) if mod.is_a?(NN::Sequential)
+          return copy_module_list(mod) if mod.is_a?(NN::ModuleList)
+
+          # Try built-in module copiers
+          copier = module_copiers[mod.class]
+          return copier.call(mod) if copier
+
+          # Fallback to generic copy for custom modules
+          copy_custom_module(mod)
+        end
+
+        # Lazily initialized registry of module copiers
+        def module_copiers
+          @module_copiers ||= {
+            NN::Linear => ->(m) { NN::Linear.new(m.in_features, m.out_features, bias: has_bias?(m)) },
+            NN::Conv1d => ->(m) { copy_conv(NN::Conv1d, m) },
+            NN::Conv2d => ->(m) { copy_conv(NN::Conv2d, m) },
+            NN::Conv3d => ->(m) { copy_conv(NN::Conv3d, m) },
+            NN::BatchNorm1d => ->(m) { copy_batch_norm(NN::BatchNorm1d, m) },
+            NN::BatchNorm2d => ->(m) { copy_batch_norm(NN::BatchNorm2d, m) },
+            NN::BatchNorm3d => ->(m) { copy_batch_norm(NN::BatchNorm3d, m) },
+            NN::LayerNorm => ->(m) {
+              NN::LayerNorm.new(m.instance_variable_get(:@normalized_shape),
+                               eps: m.instance_variable_get(:@eps),
+                               elementwise_affine: m.instance_variable_get(:@elementwise_affine))
+            },
+            NN::Embedding => ->(m) {
+              NN::Embedding.new(m.instance_variable_get(:@num_embeddings),
+                               m.instance_variable_get(:@embedding_dim),
+                               padding_idx: m.instance_variable_get(:@padding_idx))
+            },
+            NN::Dropout => ->(m) { NN::Dropout.new(p: m.instance_variable_get(:@p)) },
+            NN::Dropout2d => ->(m) { NN::Dropout2d.new(p: m.instance_variable_get(:@p)) },
+            NN::Dropout3d => ->(m) { NN::Dropout3d.new(p: m.instance_variable_get(:@p)) },
+            NN::LSTM => ->(m) { copy_rnn(NN::LSTM, m) },
+            NN::GRU => ->(m) { copy_rnn(NN::GRU, m) },
+            NN::RNN => ->(m) { copy_rnn(NN::RNN, m) },
+            NN::ReLU => ->(_) { NN::ReLU.new },
+            NN::GELU => ->(_) { NN::GELU.new },
+            NN::Tanh => ->(_) { NN::Tanh.new },
+            NN::Sigmoid => ->(_) { NN::Sigmoid.new },
+            NN::Identity => ->(_) { NN::Identity.new },
+            NN::Softmax => ->(m) { NN::Softmax.new(dim: m.instance_variable_get(:@dim)) },
+            NN::LogSoftmax => ->(m) { NN::LogSoftmax.new(dim: m.instance_variable_get(:@dim)) },
+          }
+        end
+
+        def has_bias?(mod)
+          !mod.instance_variable_get(:@bias).nil?
+        end
+
+        def copy_conv(klass, mod)
+          klass.new(mod.in_channels, mod.out_channels, mod.kernel_size,
+                    stride: mod.stride, padding: mod.padding, dilation: mod.dilation,
+                    groups: mod.groups, bias: has_bias?(mod), padding_mode: mod.padding_mode)
+        end
+
+        def copy_batch_norm(klass, mod)
+          klass.new(mod.num_features, eps: mod.eps, momentum: mod.momentum,
+                    affine: mod.affine, track_running_stats: mod.track_running_stats)
+        end
+
+        def copy_rnn(klass, mod)
+          klass.new(mod.input_size, mod.hidden_size, num_layers: mod.num_layers,
+                    bias: mod.bias, batch_first: mod.batch_first,
+                    dropout: mod.dropout, bidirectional: mod.bidirectional)
+        end
+
+        def copy_sequential(mod)
+          NN::Sequential.new(*mod.children.map { |child| deep_copy_module(child) })
+        end
+
+        def copy_module_list(mod)
+          NN::ModuleList.new(mod.map { |child| deep_copy_module(child) })
+        end
+
+        def copy_custom_module(mod)
+          klass = mod.class
+          children = mod.named_children.to_h
+
+          if children.any?
+            # Module has submodules - create structural copy
+            replica = klass.allocate
+            replica.send(:initialize_module_state)
+            copy_instance_state(mod, replica)
+            children.each do |name, child|
+              replica.instance_variable_set("@#{name}", deep_copy_module(child))
+            end
+            replica
+          else
+            # Leaf module - try clone
+            mod.clone
+          end
+        rescue => e
+          raise ArgumentError, "Cannot replicate #{klass}. " \
+            "Implement #{klass}._replicate(mod) class method. Error: #{e.message}"
+        end
+
+        def copy_instance_state(src, dst)
+          src.instance_variables.each do |ivar|
+            next if %i[@parameters @buffers @modules @training @non_persistent_buffers_set].include?(ivar)
+            val = src.instance_variable_get(ivar)
+            next if val.is_a?(Torch::Tensor) || val.is_a?(NN::Module)
+            dst.instance_variable_set(ivar, val)
+          end
+        end
+      end
+    end
+
+    # Add helper method to Module for initializing state
+    class Module
+      private
+
+      def initialize_module_state
+        @training = true
+        @parameters = {}
+        @buffers = {}
+        @modules = {}
+        @non_persistent_buffers_set = Set.new
+      end
+    end
+  end
+end

--- a/test/cuda_test.rb
+++ b/test/cuda_test.rb
@@ -6,6 +6,38 @@ class CUDATest < Minitest::Test
     assert Torch::CUDA.device_count
   end
 
+  def test_current_device
+    skip "CUDA not available" unless Torch::CUDA.available?
+
+    device = Torch::CUDA.current_device
+    assert_kind_of Integer, device
+    assert device >= 0
+    assert device < Torch::CUDA.device_count
+  end
+
+  def test_set_device
+    skip "CUDA not available" unless Torch::CUDA.available?
+
+    original_device = Torch::CUDA.current_device
+    Torch::CUDA.set_device(0)
+    assert_equal 0, Torch::CUDA.current_device
+
+    # Restore original device
+    Torch::CUDA.set_device(original_device)
+  end
+
+  def test_synchronize
+    skip "CUDA not available" unless Torch::CUDA.available?
+
+    # Should not raise
+    Torch::CUDA.synchronize
+  end
+
+  def test_nccl_available
+    result = Torch::CUDA.nccl_available?
+    assert [true, false].include?(result)
+  end
+
   def test_device
     device = Torch.device("cpu")
     assert_equal "cpu", device.type

--- a/test/data_parallel_test.rb
+++ b/test/data_parallel_test.rb
@@ -1,0 +1,283 @@
+require_relative "test_helper"
+
+class DataParallelTest < Minitest::Test
+  def test_scatter_cpu
+    input = Torch.arange(12).reshape(4, 3)
+    devices = ["cpu", "cpu"]
+
+    scattered = Torch::NN._scatter(input, devices, 0)
+
+    assert_equal 2, scattered.length
+    assert_equal [2, 3], scattered[0].shape
+    assert_equal [2, 3], scattered[1].shape
+    assert_equal [[0, 1, 2], [3, 4, 5]], scattered[0].to_a
+    assert_equal [[6, 7, 8], [9, 10, 11]], scattered[1].to_a
+  end
+
+  def test_scatter_dim1
+    input = Torch.arange(12).reshape(3, 4)
+    devices = ["cpu", "cpu"]
+
+    scattered = Torch::NN._scatter(input, devices, 1)
+
+    assert_equal 2, scattered.length
+    assert_equal [3, 2], scattered[0].shape
+    assert_equal [3, 2], scattered[1].shape
+  end
+
+  def test_gather_cpu
+    t1 = Torch.tensor([[0, 1, 2], [3, 4, 5]])
+    t2 = Torch.tensor([[6, 7, 8], [9, 10, 11]])
+
+    gathered = Torch::NN._gather([t1, t2], "cpu", 0)
+
+    assert_equal [4, 3], gathered.shape
+    assert_equal Torch.arange(12).reshape(4, 3).to_a, gathered.to_a
+  end
+
+  def test_gather_dim1
+    t1 = Torch.tensor([[0, 1], [4, 5], [8, 9]])
+    t2 = Torch.tensor([[2, 3], [6, 7], [10, 11]])
+
+    gathered = Torch::NN._gather([t1, t2], "cpu", 1)
+
+    assert_equal [3, 4], gathered.shape
+    assert_equal [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]], gathered.to_a
+  end
+
+  def test_scatter_gather_roundtrip
+    input = Torch.randn(8, 4)
+    devices = ["cpu", "cpu"]
+
+    scattered = Torch::NN._scatter(input, devices, 0)
+    gathered = Torch::NN._gather(scattered, "cpu", 0)
+
+    assert_equal input.shape, gathered.shape
+    assert Torch.allclose(input, gathered)
+  end
+
+  def test_scatter_cuda
+    skip "CUDA not available" unless Torch::CUDA.available?
+    skip "Multiple GPUs required" unless Torch::CUDA.device_count >= 2
+
+    input = Torch.arange(8).reshape(4, 2).to("cuda:0")
+    devices = ["cuda:0", "cuda:1"]
+
+    scattered = Torch::NN._scatter(input, devices, 0)
+
+    assert_equal 2, scattered.length
+    assert_equal "cuda:0", scattered[0].device.to_s
+    assert_equal "cuda:1", scattered[1].device.to_s
+  end
+
+  def test_gather_cuda
+    skip "CUDA not available" unless Torch::CUDA.available?
+    skip "Multiple GPUs required" unless Torch::CUDA.device_count >= 2
+
+    t1 = Torch.tensor([[0, 1], [2, 3]], device: "cuda:0")
+    t2 = Torch.tensor([[4, 5], [6, 7]], device: "cuda:1")
+
+    gathered = Torch::NN._gather([t1, t2], "cuda:0", 0)
+
+    assert_equal [4, 2], gathered.shape
+    assert_equal "cuda:0", gathered.device.to_s
+  end
+
+  def test_data_parallel_forward_cuda
+    skip "CUDA not available" unless Torch::CUDA.available?
+    skip "Multiple GPUs required" unless Torch::CUDA.device_count >= 2
+
+    model = Torch::NN::Linear.new(10, 5).to("cuda:0")
+    dp_model = Torch::NN::DataParallel.new(model, device_ids: [0, 1])
+
+    input = Torch.randn(8, 10, device: "cuda:0")
+    output = dp_model.call(input)
+
+    assert_equal [8, 5], output.shape
+    assert_equal "cuda:0", output.device.to_s
+  end
+
+  def test_data_parallel_sequential_cuda
+    skip "CUDA not available" unless Torch::CUDA.available?
+    skip "Multiple GPUs required" unless Torch::CUDA.device_count >= 2
+
+    model = Torch::NN::Sequential.new(
+      Torch::NN::Linear.new(10, 20),
+      Torch::NN::Linear.new(20, 5)
+    ).to("cuda:0")
+
+    dp_model = Torch::NN::DataParallel.new(model, device_ids: [0, 1])
+
+    input = Torch.arange(80, dtype: :float32).reshape(8, 10).to("cuda:0")
+    output = dp_model.call(input)
+
+    assert_equal [8, 5], output.shape
+    assert_equal "cuda:0", output.device.to_s
+  end
+
+  def test_data_parallel_backward_single_gpu
+    skip "CUDA not available" unless Torch::CUDA.available?
+
+    model = Torch::NN::Linear.new(10, 5).to("cuda:0")
+    dp_model = Torch::NN::DataParallel.new(model, device_ids: [0])
+
+    input = Torch.ones(8, 10, dtype: :float32, device: "cuda:0")
+    target = Torch.ones(8, 5, dtype: :float32, device: "cuda:0")
+
+    output = dp_model.call(input)
+    loss = (output - target).pow(2).mean
+    loss.backward
+
+    assert model.weight.grad, "Weight gradient should exist"
+    assert model.bias.grad, "Bias gradient should exist"
+    assert_equal [5, 10], model.weight.grad.shape
+  end
+
+  def test_data_parallel_backward_multi_gpu
+    skip "CUDA not available" unless Torch::CUDA.available?
+    skip "Multiple GPUs required" unless Torch::CUDA.device_count >= 2
+
+    model = Torch::NN::Linear.new(10, 5).to("cuda:0")
+    dp_model = Torch::NN::DataParallel.new(model, device_ids: [0, 1])
+
+    input = Torch.ones(8, 10, dtype: :float32, device: "cuda:0")
+    target = Torch.ones(8, 5, dtype: :float32, device: "cuda:0")
+
+    output = dp_model.call(input)
+    loss = (output - target).pow(2).mean
+    loss.backward
+
+    assert model.weight.grad, "Weight gradient should exist"
+    assert model.bias.grad, "Bias gradient should exist"
+    assert_equal [5, 10], model.weight.grad.shape
+  end
+
+  def test_data_parallel_parameters
+    skip "CUDA not available" unless Torch::CUDA.available?
+
+    model = Torch::NN::Linear.new(10, 5).to("cuda:0")
+    dp_model = Torch::NN::DataParallel.new(model, device_ids: [0])
+
+    assert_equal model.parameters.size, dp_model.parameters.size
+  end
+
+  def test_data_parallel_train_eval
+    skip "CUDA not available" unless Torch::CUDA.available?
+
+    model = Torch::NN::Sequential.new(
+      Torch::NN::Linear.new(10, 5),
+      Torch::NN::Dropout.new(p: 0.5)
+    ).to("cuda:0")
+
+    dp_model = Torch::NN::DataParallel.new(model, device_ids: [0])
+
+    dp_model.train
+    assert model.instance_variable_get(:@training)
+
+    dp_model.eval
+    refute model.instance_variable_get(:@training)
+  end
+
+  def test_data_parallel_state_dict
+    skip "CUDA not available" unless Torch::CUDA.available?
+
+    model = Torch::NN::Linear.new(10, 5).to("cuda:0")
+    dp_model = Torch::NN::DataParallel.new(model, device_ids: [0])
+
+    state_dict = dp_model.state_dict
+    assert state_dict.key?("weight")
+    assert state_dict.key?("bias")
+  end
+
+  def test_data_parallel_wrapped_module
+    skip "CUDA not available" unless Torch::CUDA.available?
+
+    model = Torch::NN::Linear.new(10, 5).to("cuda:0")
+    dp_model = Torch::NN::DataParallel.new(model, device_ids: [0])
+
+    # Both accessors should return the same module
+    assert_equal model, dp_model.module
+    assert_equal model, dp_model.wrapped_module
+  end
+
+  def test_data_parallel_backward_method_multi_gpu
+    skip "CUDA not available" unless Torch::CUDA.available?
+    skip "Multiple GPUs required" unless Torch::CUDA.device_count >= 2
+
+    model = Torch::NN::Linear.new(10, 5).to("cuda:0")
+    dp_model = Torch::NN::DataParallel.new(model, device_ids: [0, 1])
+
+    input = Torch.ones(8, 10, dtype: :float32, device: "cuda:0")
+    target = Torch.zeros(8, 5, dtype: :float32, device: "cuda:0")
+
+    output = dp_model.call(input)
+    loss = (output - target).pow(2).mean
+
+    dp_model.backward(scale: 1.0)
+    loss.backward
+
+    assert model.weight.grad, "Weight gradient should exist after backward"
+    refute model.weight.grad.sum.item.zero?, "Weight gradient should be non-zero"
+  end
+
+  def test_reduce_gradients_accumulates_correctly
+    skip "CUDA not available" unless Torch::CUDA.available?
+    skip "Multiple GPUs required" unless Torch::CUDA.device_count >= 2
+
+    model = Torch::NN::Linear.new(4, 2).to("cuda:0")
+    dp_model = Torch::NN::DataParallel.new(model, device_ids: [0, 1])
+
+    input = Torch.ones(4, 4, dtype: :float32, device: "cuda:0")
+    dp_model.call(input)
+
+    replicas = dp_model.instance_variable_get(:@replicas)
+    assert_equal 2, replicas.size, "Expected 2 replicas"
+
+    replicas[0].weight.grad = Torch.ones(2, 4, device: "cuda:0")
+    replicas[1].weight.grad = Torch.ones(2, 4, device: "cuda:1") * 2
+
+    dp_model.reduce_gradients
+
+    expected_sum = 3.0 * 2 * 4
+    actual_sum = model.weight.grad.sum.item
+
+    assert_in_delta expected_sum, actual_sum, 0.01, "Gradients should be summed from all replicas"
+  end
+
+  def test_data_parallel_with_loss_returning_model
+    skip "CUDA not available" unless Torch::CUDA.available?
+    skip "Multiple GPUs required" unless Torch::CUDA.device_count >= 2
+
+    model_with_loss = Class.new(Torch::NN::Module) do
+      def initialize
+        super()
+        @linear = Torch::NN::Linear.new(10, 5)
+      end
+
+      def forward(x, targets: nil)
+        output = @linear.call(x)
+        if targets
+          loss = (output - targets).pow(2).mean
+          [output, loss]
+        else
+          output
+        end
+      end
+    end.new.to("cuda:0")
+
+    dp_model = Torch::NN::DataParallel.new(model_with_loss, device_ids: [0, 1])
+
+    input = Torch.ones(8, 10, dtype: :float32, device: "cuda:0")
+    targets = Torch.zeros(8, 5, dtype: :float32, device: "cuda:0")
+
+    output, loss = dp_model.call(input, targets: targets)
+
+    assert_equal [8, 5], output.shape
+    assert_equal [], loss.shape
+
+    dp_model.backward(scale: 1.0)
+
+    linear = model_with_loss.instance_variable_get(:@linear)
+    assert linear.weight.grad, "Weight gradient should exist"
+  end
+end

--- a/test/parallel_apply_test.rb
+++ b/test/parallel_apply_test.rb
@@ -1,0 +1,37 @@
+require_relative "test_helper"
+
+class ParallelApplyTest < Minitest::Test
+  def test_parallel_apply_cpu
+    model1 = Torch::NN::Linear.new(10, 5)
+    model2 = Torch::NN::Linear.new(10, 5)
+
+    # Copy weights so outputs are comparable
+    model2.load_state_dict(model1.state_dict)
+
+    inputs = [Torch.randn(2, 10), Torch.randn(2, 10)]
+
+    outputs = Torch::NN::Parallel.parallel_apply([model1, model2], inputs)
+
+    assert_equal 2, outputs.size
+    assert_equal [2, 5], outputs[0].shape
+    assert_equal [2, 5], outputs[1].shape
+  end
+
+  def test_parallel_apply_cuda
+    skip "CUDA not available" unless Torch::CUDA.available?
+    skip "Multiple GPUs required" unless Torch::CUDA.device_count >= 2
+
+    model = Torch::NN::Linear.new(10, 5).to("cuda:0")
+    replicas = Torch::NN::Parallel.replicate(model, ["cuda:0", "cuda:1"])
+
+    # Use arange instead of randn to avoid kernel compatibility issues with older GPUs
+    input0 = Torch.arange(20, dtype: :float32).reshape(2, 10).to("cuda:0")
+    input1 = Torch.arange(20, dtype: :float32).reshape(2, 10).to("cuda:1")
+
+    outputs = Torch::NN::Parallel.parallel_apply(replicas, [input0, input1])
+
+    assert_equal 2, outputs.size
+    assert_equal "cuda:0", outputs[0].device.to_s
+    assert_equal "cuda:1", outputs[1].device.to_s
+  end
+end

--- a/test/replicate_test.rb
+++ b/test/replicate_test.rb
@@ -1,0 +1,61 @@
+require_relative "test_helper"
+
+class ReplicateTest < Minitest::Test
+  def test_replicate_linear_cpu
+    model = Torch::NN::Linear.new(10, 5)
+    devices = ["cpu", "cpu"]
+
+    replicas = Torch::NN::Parallel.replicate(model, devices)
+
+    assert_equal 2, replicas.size
+    replicas.each do |replica|
+      assert_instance_of Torch::NN::Linear, replica
+      assert_equal [5, 10], replica.weight.shape
+      assert_equal [5], replica.bias.shape
+    end
+
+    # Check weights are equal
+    assert Torch.allclose(replicas[0].weight, replicas[1].weight)
+    assert Torch.allclose(replicas[0].bias, replicas[1].bias)
+  end
+
+  def test_replicate_sequential_cpu
+    model = Torch::NN::Sequential.new(
+      Torch::NN::Linear.new(10, 5),
+      Torch::NN::ReLU.new,
+      Torch::NN::Linear.new(5, 2)
+    )
+    devices = ["cpu", "cpu"]
+
+    replicas = Torch::NN::Parallel.replicate(model, devices)
+
+    assert_equal 2, replicas.size
+    replicas.each do |replica|
+      assert_instance_of Torch::NN::Sequential, replica
+      assert_equal 3, replica.children.size
+    end
+
+    # Check that replicas produce same output
+    input = Torch.randn(4, 10)
+    out0 = replicas[0].call(input)
+    out1 = replicas[1].call(input)
+    assert Torch.allclose(out0, out1)
+  end
+
+  def test_replicate_cuda
+    skip "CUDA not available" unless Torch::CUDA.available?
+    skip "Multiple GPUs required" unless Torch::CUDA.device_count >= 2
+
+    model = Torch::NN::Linear.new(10, 5).to("cuda:0")
+    devices = ["cuda:0", "cuda:1"]
+
+    replicas = Torch::NN::Parallel.replicate(model, devices)
+
+    assert_equal 2, replicas.size
+    assert_equal "cuda:0", replicas[0].weight.device.to_s
+    assert_equal "cuda:1", replicas[1].weight.device.to_s
+
+    # Check weights are equal (after moving to same device)
+    assert Torch.allclose(replicas[0].weight, replicas[1].weight.to("cuda:0"))
+  end
+end


### PR DESCRIPTION
# Summary

This adds `Torch::NN::DataParallel` for multi-GPU training, allowing automatic batch splitting across GPUs.

## What about torch-ddl?
I've missed the other PR adding multi-gpu (and even distributed) workloads :) I still think I should submit this, since it's much smaller changeset and has some value. Using multiple GPUs locally is simpler than setting up a cluster load for distributed learning.

## Usage

```ruby
model = MyModel.new.to("cuda:0")
dp_model = Torch::NN::DataParallel.new(model, device_ids: [0, 1])

optimizer.zero_grad
output = dp_model.call(input)
loss = criterion.call(output, target)
loss.backward
optimizer.step
```

### Models that return loss

If the model returns a scalar loss (e.g., `[logits, loss]`), use `dp_model.backward` instead of `loss.backward`:

```ruby
optimizer.zero_grad
logits, loss = dp_model.call(input, targets: targets)
dp_model.backward(scale: 1.0)
optimizer.step
```

This is necessary because gathering scalar tensors across devices breaks the autograd graph. The `backward` method calls backward on each replica's loss separately, then reduces gradients to the original module.

## What's included

**CUDA device management:**
- `Torch::CUDA.current_device` - get current CUDA device index
- `Torch::CUDA.set_device(id)` - set current CUDA device (useful for testing devices)
- `Torch::CUDA.synchronize` - wait for all CUDA operations to complete
- `Torch::CUDA.nccl_available?` - check if NCCL is available (useful for checking if we can run DataParallel)

**DataParallel:**
- `Torch::NN::DataParallel` - wraps a module for multi-GPU training
- `Torch::NN::Parallel.replicate` - copies modules to multiple devices
- `Torch::NN::Parallel.parallel_apply` - runs forward pass on replicas in parallel
- `Torch::NN._scatter` / `Torch::NN._gather` - splits and combines tensors across devices (internal methods, underscore notation mimics what's in pytorch)

## Testing

Verified with [nanogpt-rb](https://github.com/khasinski/nanogpt-rb) on 2 GPUs. Both GPUs were utilized, the speedup was...well, negative, since they were mismatched (RTX 4090 and GTX 1050 Ti) :sweat_smile: A better pairing should result in some improvement.


